### PR TITLE
CI: Build & Release

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,120 @@
+name: CMake
+
+on:
+  push:
+  pull_request:
+  release:
+    types: [created]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    name: ${{matrix.name}}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            name: Linux
+            cache-key: linux
+            cmake-args: '-DPIMORONI_PICOVISION_PATH=$GITHUB_WORKSPACE/picovision -DPIMORONI_PICO_PATH=$GITHUB_WORKSPACE/pimoroni-pico -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DPICO_EXTRAS_PATH=$GITHUB_WORKSPACE/pico-extras -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install'
+            apt-packages: clang-tidy gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+
+    runs-on: ${{matrix.os}}
+
+    env:
+      PICO_SDK_PATH: $GITHUB_WORKSPACE/pico-sdk
+      PIMORONI_PICO_LIBS: $GITHUB_WORKSPACE/pimoroni-pico
+      RELEASE_FILE: ${{github.event.repository.name}}-${{github.event.release.tag_name || github.sha}}
+      INSTALL_PREFIX: ${{github.workspace}}/install
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        path: doom
+
+    - name: Checkout Pimoroni Pico Libraries
+      uses: actions/checkout@v2
+      with:
+        repository: pimoroni/pimoroni-pico
+        path: pimoroni-pico
+
+    - name: Checkout Pimoroni PicoVision Libraries
+      uses: actions/checkout@v2
+      with:
+        repository: pimoroni/picovision
+        path: picovision
+
+    - name: Checkout Pico SDK
+      uses: actions/checkout@v2
+      with:
+        repository: raspberrypi/pico-sdk
+        path: pico-sdk
+        submodules: true
+
+    - name: Checkout Pico Extras
+      uses: actions/checkout@v2
+      with:
+        repository: raspberrypi/pico-extras
+        path: pico-extras
+
+    # Linux deps
+    - name: Install deps
+      run: |
+        sudo apt update && sudo apt install ${{matrix.apt-packages}}
+
+    - name: GCC Version?
+      run: |
+        arm-none-eabi-gcc --version
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        PICO_BOARD_HEADER_DIRS=$GITHUB_WORKSPACE/doom cmake -DPICO_BOARD=pimoroni_picovision $GITHUB_WORKSPACE/doom -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_PREFIX}} -DCPACK_PACKAGE_FILE_NAME=${{env.RELEASE_FILE}} ${{matrix.cmake-args}}
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: |
+        cmake --build . --config $BUILD_TYPE -j 2
+
+    - name: Build Release Packages
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: |
+        cmake --build . --config $BUILD_TYPE --target package install -j 2
+
+    - name: Release Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{env.RELEASE_FILE}}.zip
+        path: ${{env.INSTALL_PREFIX}}
+
+    - name: Upload .zip
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      with:
+        asset_path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip
+        upload_url: ${{github.event.release.upload_url}}
+        asset_name: ${{env.RELEASE_FILE}}.zip
+        asset_content_type: application/zip
+
+    - name: Upload .tar.gz
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      with:
+        asset_path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.tar.gz
+        upload_url: ${{github.event.release.upload_url}}
+        asset_name: ${{env.RELEASE_FILE}}.tar.gz
+        asset_content_type: application/octet-stream

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,3 +93,14 @@ configure_file(src/setup/setup-manifest.xml.in src/setup/setup-manifest.xml)
 foreach(SUBDIR textscreen midiproc opl pcsound src)
     add_subdirectory("${SUBDIR}")
 endforeach()
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/src/doom_tiny_usb.uf2
+    ${CMAKE_CURRENT_BINARY_DIR}/src/doom_tiny_nost_usb.uf2
+    ${CMAKE_CURRENT_LIST_DIR}/README.md
+    DESTINATION .
+)
+
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+set(CPACK_GENERATOR "ZIP" "TGZ")
+include(CPack)


### PR DESCRIPTION
Set up a GitHub workflow to build this project, and configure CPack to provide files for installs and release assets.

:warning: Note, it looks like "actions/upload-release-asset" is relying upon deprecated something-or-others and might break at some point 😬 but in the meantime, this should work.